### PR TITLE
fix: only support forward only streams

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.BlobStore/Aws/S3BlobClient.cs
+++ b/src/Be.Vlaanderen.Basisregisters.BlobStore/Aws/S3BlobClient.cs
@@ -45,7 +45,7 @@ namespace Be.Vlaanderen.Basisregisters.BlobStore.Aws
                                 BucketName = _bucket,
                                 Key = name.ToString()
                             }, contentCancellationToken);
-                            return contentResponse.ResponseStream;
+                            return new ForwardOnlyStream(contentResponse.ResponseStream);
                         }
                         catch (AmazonS3Exception exception) when (
                             exception.ErrorType == ErrorType.Sender

--- a/src/Be.Vlaanderen.Basisregisters.BlobStore/ForwardOnlyStream.cs
+++ b/src/Be.Vlaanderen.Basisregisters.BlobStore/ForwardOnlyStream.cs
@@ -1,0 +1,66 @@
+namespace Be.Vlaanderen.Basisregisters.BlobStore
+{
+    using System;
+    using System.IO;
+
+    //origin: https://github.com/adamhathcock/sharpcompress
+
+    internal class ForwardOnlyStream : Stream
+    {
+        private readonly Stream _stream;
+        private bool _disposed;
+
+        public ForwardOnlyStream(Stream stream)
+        {
+            _stream = stream;
+            _disposed = false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (!disposing) return;
+
+            _stream.Dispose();
+            _disposed = true;
+            base.Dispose(true);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _stream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Be.Vlaanderen.Basisregisters.BlobStore/IO/FileBlobClient.cs
+++ b/src/Be.Vlaanderen.Basisregisters.BlobStore/IO/FileBlobClient.cs
@@ -63,7 +63,7 @@ namespace Be.Vlaanderen.Basisregisters.BlobStore.IO
                             if(valueLength != -1) contentReader.ReadString();
                         }
                     }
-                    return Task.FromResult<Stream>(contentFileStream);
+                    return Task.FromResult<Stream>(new ForwardOnlyStream(contentFileStream));
                 }));
             }
         }

--- a/src/Be.Vlaanderen.Basisregisters.BlobStore/Memory/MemoryBlobClient.cs
+++ b/src/Be.Vlaanderen.Basisregisters.BlobStore/Memory/MemoryBlobClient.cs
@@ -60,7 +60,7 @@ namespace Be.Vlaanderen.Basisregisters.BlobStore.Memory
                 {
                     if (_storage.ContainsKey(name))
                     {
-                        return Task.FromResult<Stream>(new MemoryStream(buffer, false));
+                        return Task.FromResult<Stream>(new ForwardOnlyStream(new MemoryStream(buffer, false)));
                     }
 
                     throw new BlobNotFoundException(name);

--- a/src/Be.Vlaanderen.Basisregisters.BlobStore/Sql/SqlBlobClient.cs
+++ b/src/Be.Vlaanderen.Basisregisters.BlobStore/Sql/SqlBlobClient.cs
@@ -68,11 +68,13 @@ namespace Be.Vlaanderen.Basisregisters.BlobStore.Sql
                                             contentCancellationToken);
                                     if (!contentReader.IsClosed && contentReader.Read())
                                     {
-                                        return new DisposableStream(
-                                            contentReader.GetStream(0),
-                                            contentReader,
-                                            contentCommand,
-                                            contentConnection);
+                                        return new ForwardOnlyStream(
+                                            new DisposableStream(
+                                                contentReader.GetStream(0),
+                                                contentReader,
+                                                contentCommand,
+                                                contentConnection)
+                                        );
                                     }
 
                                     throw new BlobNotFoundException(name);


### PR DESCRIPTION
consumers must not assume the blob content stream is seekable nor writable (mitigates issues with ZipArchive trying to reset position which causes unexpected behavior when using the FileBlobClient).